### PR TITLE
Fix memory leak when resizing histogram

### DIFF
--- a/histogram/histogram.cuh
+++ b/histogram/histogram.cuh
@@ -77,6 +77,9 @@ public:
         if(bufferSize < logicSize){
             cudaErrChk(cudaFreeHost(hostPtr));
             cudaErrChk(cudaFree(cudaPtr));
+            for(int i=0; i<dim; i++){
+                cudaErrChk(cudaFree(scaleMark[i]));
+            }
             bufferSize = logicSize;
             allocate();
         }


### PR DESCRIPTION
## Summary
- Prevent memory leak when resizing histogram buffers by freeing existing scaleMark arrays before reallocation

## Testing
- `cmake ..` (fails: Failed to find nvcc; Compiler requires the CUDA toolkit.)

------
https://chatgpt.com/codex/tasks/task_e_6895c26f9f04832789deb05a1a8cee91